### PR TITLE
Fix incorrect tensor comparison in self-attention assertion

### DIFF
--- a/monkey_model/visual.py
+++ b/monkey_model/visual.py
@@ -254,7 +254,7 @@ class VisualAttention(nn.Module):
         # query/key/value: [sq, b, h]
         sq, b, _ = query.size()
 
-        assert query is key, 'Only Support Self-Attention Currently'
+        assert torch.equal(query, key), 'Only Support Self-Attention Currently'
         sk = sq
         mixed_x_layer = self.in_proj(query)
         if idx == None:


### PR DESCRIPTION
# Descrition

I found an issue in the code where the assert statement incorrectly checks if query and key are the same. Since query and key are tensors, using assert query is key is not appropriate for comparing their values.

To properly compare the values of the two tensors, torch.equal should be used. This function compares each element of the tensors, ensuring they have the same values.

# Proposed Change

Modify line 257 from:
`assert query is key, 'Only Support Self-Attention Currently'
`

to:
`assert torch.equal(query, key), 'Only Support Self-Attention Currently'
`
